### PR TITLE
Don't link stdc++ when using bundled libbrotli

### DIFF
--- a/src/brotli/build.py
+++ b/src/brotli/build.py
@@ -11,8 +11,8 @@ if USE_SHARED_BROTLI != "1":
 else:
     libraries = ['brotlienc', 'brotlidec']
 
-if 'win32' not in str(sys.platform).lower():
-    libraries.append('stdc++')
+    if 'win32' not in str(sys.platform).lower():
+        libraries.append('stdc++')
 
 
 ffi.set_source(


### PR DESCRIPTION
The bundled libbrotli doesn't appear to require c++ support.