### PR TITLE
Explicitly depend on enum34 for Python < 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,7 @@ setup(
     ],
     install_requires=[
         "cffi>=1.0.0",
+        "enum34;python_version<'3.4'",
     ],
     cffi_modules=["src/brotlicffi/_build.py:ffi"],
     packages=find_packages('src'),


### PR DESCRIPTION
Add an explicit dependency on enum34 for Python < 3.4 (notably 2.7 that
is still seemingly supported).  This is necessary for brotlicffi to
seamlessly replace brotlipy in deps still claiming to support py2.7.
The package's tests do not fail because enum34 is brought indirectly
by the test dependencies.