### PR TITLE
Multiple pytest/hypothesis fixes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[tool:pytest]
+addopts = --strict-markers
+markers =
+	slow: marks tests as slow (deselect with '-m "not slow"')

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -25,6 +25,6 @@ def simple_compressed_file(request):
     return (file[:-len('.compressed')], file)
 
 
-@pytest.fixture()
+@pytest.fixture(scope='session')
 def one_compressed_file():
     return os.path.join(TEST_DATA_DIR, 'alice29.txt')

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,3 @@
-pytest==3.8.1
-pytest-cov==2.6.0
+pytest
+pytest-cov
 hypothesis


### PR DESCRIPTION
A few fixes to pytest/hypothesis-related problems:

1. Unbind pytest dep because old version of pytest caused hypothesis tests to be skipped.
2. Fix hypothesis health checks due to `one_compressed_file` fixture missing scope.
3. Fix pytest warning due to unregistered marks.