### PR TITLE
Avoid bytes/string comparison

### DIFF
--- a/src/brotlicffi/_api.py
+++ b/src/brotlicffi/_api.py
@@ -402,7 +402,7 @@ class Decompressor(object):
                 error_code = lib.BrotliDecoderGetErrorCode(self._decoder)
                 error_message = lib.BrotliDecoderErrorString(error_code)
                 raise error(
-                    "Decompression error: %s" % ffi.string(error_message)
+                    b"Decompression error: %s" % ffi.string(error_message)
                 )
 
             # Next, copy the result out.

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py27, py34, py35, py36, py37, py38, py39, pypy, lint
 
 [testenv]
 deps= -r{toxinidir}/test_requirements.txt
-commands= py.test --cov brotlicffi {posargs} {toxinidir}/test/
+commands= python -bb -m pytest --cov brotlicffi {posargs} {toxinidir}/test/
 
 [testenv:pypy]
 # temporarily disable coverage testing on PyPy due to performance problems


### PR DESCRIPTION
This can be reproduced by running urllib3's test suite using `python -bb -m pytest ...`.