### PR TITLE
License file to be included into metadata dir

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,6 @@
 addopts = --strict-markers
 markers =
 	slow: marks tests as slow (deselect with '-m "not slow"')
+
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
Grüß Gott! ;-)
Please, add the LICENSE file into metadata dir of your package (e.g. by accepting this pull request).
I understand you probably hate software laws etc., so I will be short.

You are using MIT license. It says also: "The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software." But your whole package distributed on PyPI.org does not contain even one. This short change will add the file LICENSE (with text of MIT license) into metadata of your package (= into e.g. .../site-packages/brotlipy-0.7.0-py3.9.egg-info/LICENSE of your virtualenv). This way you are 100% clear and comply with your chosen license.

Thank you for your time.
Pax et bonum.