### PR TITLE
Prepare v1.2.0.2 release

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+1.2.0.2 (2026-08-21)
+--------------------
+
+- Fixed a bug where ``Decompressor.decompress()`` could leave stale
+  unconsumed input behind after fully consuming a chunk of compressed
+  data, causing subsequent calls to fail or re-process old data.
+- Since cibuildwheel dropped support, this release does not include Python 3.8 wheels.
+
 1.2.0.1 (2026-03-05)
 --------------------
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-1.2.0.1 (2025-03-05)
+1.2.0.1 (2026-03-05)
 --------------------
 
 - Added support for the free-threaded build of Python 3.14.

--- a/src/brotlicffi/__init__.py
+++ b/src/brotlicffi/__init__.py
@@ -5,4 +5,4 @@ from ._api import (
     Compressor, MODE_GENERIC, MODE_TEXT, MODE_FONT, error, Error
 )
 
-__version__ = "1.2.0.1"
+__version__ = "1.2.0.2"


### PR DESCRIPTION
Also fixes a typo in the v1.2.0.1 release date.